### PR TITLE
Hotfix for version 0.3.2: Fixing panic issues and upgrade to mongodb rust driver version 3.X

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,14 @@ graphql = ["juniper"]
 
 [dependencies]
 base64 = "0.22.1"
-bson = "2.5.0"
-log = "0.4.17"
-mongodb = "2.3.1"
-serde = "1.0"
+bson = "2"
+log = "0.4"
+mongodb = "3"
+serde = "1"
 juniper = { version = "0.16.1", optional = true }
-futures = "0.3.26"
-futures-util = "0.3.26"
+futures = "0.3"
+futures-util = "0.3"
+tokio = "1"
 
 [dev-dependencies]
-tokio = { version = "1.25.0", features = ["full"]}
+tokio = { version = "1", features = ["full"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mongodb-cursor-pagination"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Kylian Lichtensteiger <e38c1a93@srylax.dev"]
 edition = "2021"
 license = "MIT"
@@ -16,12 +16,12 @@ default = []
 graphql = ["juniper"]
 
 [dependencies]
-base64 = "0.21.0"
+base64 = "0.22.1"
 bson = "2.5.0"
 log = "0.4.17"
 mongodb = "2.3.1"
 serde = "1.0"
-juniper = { version = "0.15.11", optional = true }
+juniper = { version = "0.16.1", optional = true }
 futures = "0.3.26"
 futures-util = "0.3.26"
 

--- a/examples/default.rs
+++ b/examples/default.rs
@@ -14,7 +14,7 @@ async fn main() {
 
     // Ensure there is no collection myfruits
     db.collection::<MyFruit>("myfruits")
-        .drop(None)
+        .drop()
         .await
         .expect("Failed to drop table");
 
@@ -27,7 +27,7 @@ async fn main() {
     ];
 
     db.collection("myfruits")
-        .insert_many(docs, None)
+        .insert_many(docs)
         .await
         .expect("Unable to insert data");
 
@@ -111,7 +111,7 @@ async fn main() {
     );
 
     db.collection::<MyFruit>("myfruits")
-        .drop(None)
+        .drop()
         .await
         .expect("Unable to drop collection");
 }

--- a/examples/multisort.rs
+++ b/examples/multisort.rs
@@ -14,7 +14,7 @@ async fn main() {
 
     // Ensure there is no collection myfruits
     db.collection::<MyFruit>("myfruits")
-        .drop(None)
+        .drop()
         .await
         .expect("Failed to drop table");
 
@@ -38,7 +38,8 @@ async fn main() {
     // Blackberry | 12
 
     db.collection("myfruits")
-        .insert_many(docs, None)
+        .insert_many(docs)
+        .with_options(None)
         .await
         .expect("Unable to insert data");
 
@@ -142,7 +143,8 @@ async fn main() {
     );
 
     db.collection::<Document>("myfruits")
-        .drop(None)
+        .drop()
+        .with_options(None)
         .await
         .expect("Unable to drop collection");
 }

--- a/examples/regex.rs
+++ b/examples/regex.rs
@@ -15,7 +15,7 @@ async fn main() {
 
     // Ensure there is no collection myfruits
     db.collection::<MyFruit>("myfruits")
-        .drop(None)
+        .drop()
         .await
         .expect("Failed to drop table");
 
@@ -42,7 +42,7 @@ async fn main() {
     // Blackberry | 12
 
     db.collection("myfruits")
-        .insert_many(docs, None)
+        .insert_many(docs)
         .await
         .expect("Unable to insert data");
 
@@ -137,7 +137,7 @@ async fn main() {
     print_details("Previous (second) page", &find_results);
 
     db.collection::<MyFruit>("myfruits")
-        .drop(None)
+        .drop()
         .await
         .expect("Unable to drop collection");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ impl PaginatedCursor {
         count_options.skip = None;
         let count_query = query.map_or_else(Document::new, Clone::clone);
         let total_count = collection
-            .count_documents(count_query /*Some(CountOptions::from(count_options))*/)
+            .count_documents(count_query)
             .with_options(CountOptions::from(count_options))
             .await
             .map_err(|err| CursorError::Unknown(err.to_string()))?;
@@ -353,7 +353,7 @@ impl PaginatedCursor {
             }
         }
         let mut cursor = collection
-            .find(query_doc /*Some(options.into())*/)
+            .find(query_doc)
             .with_options(<CursorOptions as Into<FindOptions>>::into(options))
             .await
             .map_err(|err| CursorError::Unknown(err.to_string()))?;


### PR DESCRIPTION
Delegate  fatal error handling to the users of the library,

## Linked Items
This PR is a hot fix for version **0.3.2**. It is related to this commit a578bb4e1ac6d27204f568c686e007410ab068be
And should be compared to it. The base branch to be compared against would be one that is based from this commit a578bb4e1ac6d27204f568c686e007410ab068be

 This Pr is not intended to be merged with master.

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

This PR fixes panic errors caused by the library due to the explicit use of **unwrap()** calls upon **Result** and **Option<T>**
This causes application to crash with panic. And it fixes build errors with Mongodb Rust Driver V3.X

This PR is not intended to be merged with Master. it is intended as a hot fix for the current stable release which is 0.3.2.

As it's been one year since this latest release candidate has not been released. This fix is really mandatory for the current stable release which me and other peers are using.

## Behaviour changes

Old: Panic and caused application to crash if there are database or base64 encoding/decoding errors or any other types by the use of unsafe **unwrap** upon **Result** or **Option** type

New: Map non related errors as CursorError::Unknown(String)  and delegate the errors the caller(library users). Errors are being handled by application instead of the library

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [x] Refactoring
- [x] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
